### PR TITLE
Add django-stubs to dev requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,32 +5,38 @@
 #    pip-compile --extra=dev --output-file=dev-requirements.txt
 #
 asgiref==3.8.1
-    # via django
+    # via
+    #   django
+    #   django-stubs
 build==1.2.2.post1
     # via pip-tools
 cfgv==3.4.0
     # via pre-commit
 click==8.1.7
     # via pip-tools
-colorama==0.4.6
-    # via
-    #   build
-    #   click
-    #   pytest
 coverage[toml]==7.6.4
     # via pytest-cov
 distlib==0.3.9
     # via virtualenv
 django==5.1.2
+    # via
+    #   django-stubs
+    #   django-stubs-ext
+    #   rse_competencies_toolkit (pyproject.toml)
+django-stubs[compatible-mypy]==5.1.0
     # via rse_competencies_toolkit (pyproject.toml)
+django-stubs-ext==5.1.0
+    # via django-stubs
 filelock==3.16.1
     # via virtualenv
 identify==2.6.1
     # via pre-commit
 iniconfig==2.0.0
     # via pytest
-mypy==1.12.1
-    # via rse_competencies_toolkit (pyproject.toml)
+mypy==1.11.2
+    # via
+    #   django-stubs
+    #   rse_competencies_toolkit (pyproject.toml)
 mypy-extensions==1.0.0
     # via mypy
 nodeenv==1.9.1
@@ -62,14 +68,17 @@ pytest-mock==3.14.0
     # via rse_competencies_toolkit (pyproject.toml)
 pyyaml==6.0.2
     # via pre-commit
-ruff==0.7.0
+ruff==0.7.1
     # via rse_competencies_toolkit (pyproject.toml)
 sqlparse==0.5.1
     # via django
+types-pyyaml==6.0.12.20240917
+    # via django-stubs
 typing-extensions==4.12.2
-    # via mypy
-tzdata==2024.2
-    # via django
+    # via
+    #   django-stubs
+    #   django-stubs-ext
+    #   mypy
 virtualenv==20.27.0
     # via pre-commit
 wheel==0.44.0

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -18,9 +18,7 @@ click==8.1.7
     #   mkdocstrings
 colorama==0.4.6
     # via
-    #   click
     #   griffe
-    #   mkdocs
     #   mkdocs-material
 django==5.1.2
     # via rse_competencies_toolkit (pyproject.toml)
@@ -116,8 +114,6 @@ requests==2.32.3
 six==1.16.0
     # via python-dateutil
 sqlparse==0.5.1
-    # via django
-tzdata==2024.2
     # via django
 urllib3==2.2.3
     # via requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "pytest-mock",
+    "django-stubs[compatible-mypy]",
 ]
 doc = [
     "mkdocs",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,5 @@ django==5.1.2
     # via rse_competencies_toolkit (pyproject.toml)
 sqlparse==0.5.1
     # via django
-tzdata==2024.2
-    # via django
 whitenoise==6.7.0
     # via rse_competencies_toolkit (pyproject.toml)


### PR DESCRIPTION
# Description

This adds Django-stubs to the development requirements and updates the pinned requirements files

Fixes #27 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
