### PR TITLE
Correct the command for checking that documents build in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@ Fixes # (issue)
 ## Key checklist
 
 - [ ] All tests pass (eg. `python -m pytest`)
-- [ ] The documentation builds and looks OK (eg. `python -m sphinx -b html docs docs/build`)
+- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
 - [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)
 
 ## Further checks


### PR DESCRIPTION
# Description

Replace reference to building docs using sphinx with correct command using MKDocs.

Fixes #26 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

~~Tests are failing but not as a result of the proposed changes.~~ Test pass after updating virtual env!

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
