### PR TITLE
Configure pytest-django

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -60,9 +60,12 @@ pyproject-hooks==1.2.0
 pytest==8.3.3
     # via
     #   pytest-cov
+    #   pytest-django
     #   pytest-mock
     #   rse_competencies_toolkit (pyproject.toml)
 pytest-cov==5.0.0
+    # via rse_competencies_toolkit (pyproject.toml)
+pytest-django==4.9.0
     # via rse_competencies_toolkit (pyproject.toml)
 pytest-mock==3.14.0
     # via rse_competencies_toolkit (pyproject.toml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
+    "pytest-django",
     "pytest-mock",
     "django-stubs[compatible-mypy]",
 ]
@@ -53,6 +54,7 @@ disallow_untyped_defs = false
 
 [tool.pytest.ini_options]
 addopts = "-v -p no:warnings --cov=rse_competencies_toolkit --cov-report=html --doctest-modules --ignore=rse_competencies_toolkit/__main__.py --ignore=docs --ignore=rse_competencies_toolkit/settings/"
+DJANGO_SETTINGS_MODULE = "rse_competencies_toolkit.settings"
 
 [tool.ruff]
 target-version = "py312"


### PR DESCRIPTION
# Description

This PR adds `pytest-django` to dev dependencies and configures it to know where the settings module is.

Note: this is being done before #10 because the tests were failing when working on that issue.

@davehorsfall tagging you to keep you in the loop

Fixes #13 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
