### PR TITLE
Create a very basic index view

### DIFF
--- a/main/templates/main/base.html
+++ b/main/templates/main/base.html
@@ -1,0 +1,13 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>{% block title %}RSE Competencies Toolkit{% endblock %}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+
+<body>
+      {% block content %}{% endblock %}
+</body>
+</html>

--- a/main/templates/main/index.html
+++ b/main/templates/main/index.html
@@ -1,0 +1,7 @@
+{% extends "main/base.html" %}
+
+{% block title %}RSE Competencies Toolkit{% endblock title %}
+
+{% block content %}
+Welcome to the index page for the RSE Competencies Toolkit!
+{% endblock content %}

--- a/main/tests.py
+++ b/main/tests.py
@@ -1,1 +1,0 @@
-"""Create your tests here."""

--- a/main/urls.py
+++ b/main/urls.py
@@ -1,0 +1,9 @@
+"""Urls module for the main app."""
+
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path("", views.index, name="index"),
+]

--- a/main/views.py
+++ b/main/views.py
@@ -1,1 +1,9 @@
-"""Create your views here."""
+"""Views for the main app."""
+
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+
+
+def index(request: HttpRequest) -> HttpResponse:
+    """View that renders the index/home page."""
+    return render(request=request, template_name="main/index.html")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ disallow_untyped_defs = false
 [tool.pytest.ini_options]
 addopts = "-v -p no:warnings --cov=rse_competencies_toolkit --cov-report=html --doctest-modules --ignore=rse_competencies_toolkit/__main__.py --ignore=docs --ignore=rse_competencies_toolkit/settings/"
 DJANGO_SETTINGS_MODULE = "rse_competencies_toolkit.settings"
+FAIL_INVALID_TEMPLATE_VARS = true
 
 [tool.ruff]
 exclude = ["main/migrations"]

--- a/rse_competencies_toolkit/urls.py
+++ b/rse_competencies_toolkit/urls.py
@@ -16,8 +16,9 @@ Including another URLconf
 """
 
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("", include("main.urls")),
 ]

--- a/tests/main/test_views.py
+++ b/tests/main/test_views.py
@@ -1,0 +1,8 @@
+from pytest_django.asserts import assertTemplateUsed
+
+
+def test_index(client, admin_client):
+    """Test the index view."""
+    with assertTemplateUsed(template_name="main/index.html"):
+        response = client.get("/")
+    assert response.status_code == 200

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,6 +1,0 @@
-"""Basic test views."""
-
-
-def test_views():
-    """Test view."""
-    pass


### PR DESCRIPTION
# Description

This PR adds a very basic index page to the repo. The page does nothing and has no static content or stylesheet, but it provides an initial routing for the urls and views that we can build from. It also adds a test which can serve as an example for writing tests going forward.

Notes on the purpose of what has been added:
- HTML Templates - Provide a template from which Django can build a HTML page. See [Django Templates](https://docs.djangoproject.com/en/5.1/topics/templates/) for more
- `main/urls.py` - Routes URL patterns to views
- `rse_competencies_toolkit/urls.py` - Includes the URLs in the `main` app in the Django project
- `views.py` - For defining backend "views", which handle HTTP Requests and return HTTP responses. The Index View takes a GET request and renders the index page based off the `index.html` template
- `test_views.py` - Tests that the index view returns an ok status code

@davehorsfall tagging you to keep you in the loop

Fixes #11 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
