### PR TITLE
Build API docs from the main app and not the project app

### DIFF
--- a/docs/gen_ref_nav.py
+++ b/docs/gen_ref_nav.py
@@ -6,13 +6,15 @@ import mkdocs_gen_files
 
 nav = mkdocs_gen_files.Nav()
 
-for path in sorted(Path("rse_competencies_toolkit").glob("**/*.py")):
+for path in sorted(Path("main").glob("**/*.py")):
     module_path = path.relative_to(".").with_suffix("")
     doc_path = path.relative_to(".").with_suffix(".md")
     full_doc_path = Path("reference", doc_path)
 
     parts = list(module_path.parts)
     if ".array_cache" in parts:
+        continue
+    elif "migrations" in parts:
         continue
     elif parts[-1] == "__init__":
         parts = parts[:-1]

--- a/main/views.py
+++ b/main/views.py
@@ -5,5 +5,9 @@ from django.shortcuts import render
 
 
 def index(request: HttpRequest) -> HttpResponse:
-    """View that renders the index/home page."""
+    """View that renders the index/home page.
+
+    Args:
+      request: A GET request.
+    """
     return render(request=request, template_name="main/index.html")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: RSE Competencies Toolkit
-watch: [rse_competencies_toolkit]
+watch: [main]
 
 theme:
   name: material


### PR DESCRIPTION
# Description

Quick fix for an issue with the docs not showing the API documentation of the main app (which is where all the unique views and models will be).

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
