### PR TITLE
Include all relevant modules in test coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ module = "tests.*"
 disallow_untyped_defs = false
 
 [tool.pytest.ini_options]
-addopts = "-v -p no:warnings --cov=rse_competencies_toolkit --cov-report=html --doctest-modules --ignore=rse_competencies_toolkit/__main__.py --ignore=docs --ignore=rse_competencies_toolkit/settings/"
+addopts = "-v -p no:warnings --cov=. --cov-report=html --doctest-modules --ignore=rse_competencies_toolkit/__main__.py --ignore=docs --ignore=rse_competencies_toolkit/settings/"
 DJANGO_SETTINGS_MODULE = "rse_competencies_toolkit.settings"
 FAIL_INVALID_TEMPLATE_VARS = true
 
@@ -80,3 +80,6 @@ pydocstyle.convention = "google"
 
 [tool.django-stubs]
 django_settings_module = "rse_competencies_toolkit.settings"
+
+[tool.coverage.run]
+omit = ["tests/*"]


### PR DESCRIPTION
# Description

Test coverage was only checking the `rse_competencies_toolkit` module and not the `main` module

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
